### PR TITLE
Make Editor fields non-static

### DIFF
--- a/src/editor.py
+++ b/src/editor.py
@@ -1,5 +1,7 @@
 class Editor:
-    classes = {}
+    def __init__(self):
+        self.classes = {}
+
     def classAdd(self, name):
         pass
     def classDelete(self, name):


### PR DESCRIPTION
This fixes a bug I discovered when testing, which is that I need to add fields in __init__ instead of just in the class definition. The fields now are static and caused tests to fail in my feature branch.