### PR TITLE
classRename and listClass/Classes/Relationships bugs

### DIFF
--- a/src/editor.py
+++ b/src/editor.py
@@ -142,11 +142,9 @@ class Editor:
         related_classes = []
         for relationship in self.relationships:
             if relationship[0] == class_name:
-                if relationship[1] != class_name:
-                    related_classes.append(relationship[1])
+                related_classes.append((relationship[1], 'outgoing'))
             elif relationship[1] == class_name:
-                if relationship[0] != class_name:
-                    related_classes.append(relationship[0])
+                related_classes.append((relationship[0], 'incoming'))
         return related_classes
 
     # Function which lists all other classes a specific class has a relationship with
@@ -159,8 +157,11 @@ class Editor:
             # Find relationships that include the current class
             related_classes = self.findRelationships(class_name)
 
-            for relationship in related_classes:
-                print(f'{relationship} ---- {class_name}')
+            for relationship, direction in related_classes:
+                if direction == 'outgoing':
+                    print(f'{class_name} ----> {relationship}')
+                else: 
+                    print(f'{relationship} ----> {class_name}')
         else:
             print(f'{class_name} does not exist.')
 
@@ -182,8 +183,11 @@ class Editor:
 
             if related_classes:
                 print('Relationships: ')
-                for relationship in related_classes:
-                    print(f'{relationship} ---- {class_name}')
+                for relationship, direction in related_classes:
+                    if direction == 'outgoing':
+                        print(f'{class_name} ----> {relationship}')
+                    else: 
+                        print(f'{relationship} ----> {class_name}')
             else:
                 print('Relationships: None')
 
@@ -194,5 +198,8 @@ class Editor:
 
     # Function which lists all classes and contents of each class
     def listClasses(self):
-        for class_name in self.classes:
-            self.listClass(class_name)
+        if self.classes:
+            for class_name in self.classes:
+                self.listClass(class_name)
+        else:
+            print("There are no classes yet")

--- a/src/editor.py
+++ b/src/editor.py
@@ -27,7 +27,7 @@ class Editor:
         elif rename in self.classes:
             print(f'ERROR: {rename} is an already existing class. Cannot rename.')
         else: 
-            print(f'ERROR: {rename} does not exist. Cannot rename.')
+            print(f'ERROR: {name} does not exist. Cannot rename.')
 
     # Function which adds a relationship between class1 and class2, which are both strings
     def relationshipAdd(self, class1, class2):
@@ -57,11 +57,6 @@ class Editor:
             print(f'ERROR: class `{class2}` does not exist')
         else:
             print(f'ERROR: there is no relationship between `{class1}` and `{class2}`')
-
-    # Function which lists all classes and contents of each class
-    def listClasses(self):
-        for class_name in self.classes:
-            self.listClass(class_name)
     
     # Function renames given attribute in given class if both exist and new name does not
     def renameAttribute(self, class1, attribute1, attribute2):
@@ -174,7 +169,15 @@ class Editor:
         if class_name in self.classes:
             print(f'Class: {class_name}')
 
-            # First, print all relationships
+            # First, print all attributes
+            if self.classes[class_name].attributtesSets:
+                print('Attributes:')
+                for attribute in self.classes[class_name].attributtesSets:
+                    print(f'  {attribute}')
+            else:
+                print('Attributes: None')   
+
+            # Then, print all relationships
             related_classes = self.findRelationships(class_name)
 
             if related_classes:
@@ -184,15 +187,12 @@ class Editor:
             else:
                 print('Relationships: None')
 
-            # Then, print all attributes
-            if self.classes[class_name].attributtesSets:
-                print('Attributes:')
-                for attribute in self.classes[class_name].attributtesSets:
-                    print(f'  {attribute}')
-            else:
-                print('Attributes: None')            
-
             print()
 
         else:
-            print(f'Class "{class_name}" does not exist.')         
+            print(f'Class "{class_name}" does not exist.')    
+
+    # Function which lists all classes and contents of each class
+    def listClasses(self):
+        for class_name in self.classes:
+            self.listClass(class_name)


### PR DESCRIPTION
- Fixed the output of the list commands so that attributes is listed before relationships
- Fixed the relationships output of the list commands so that relationships are directional depending on which class was entered first (class1 ----> class2)
- Fixed incorrect message when renaming a class that doesn't exist. If 'Foo' is attempted to be renamed to 'Foo2', the message will now read "ERROR: Foo does not exist. Cannot rename." Instead of "ERROR: Foo2 does not exist. Cannot rename."