### PR TITLE
Fix misuse of python lambda for previous classDelete bugfix

### DIFF
--- a/src/controller/editor_controller.py
+++ b/src/controller/editor_controller.py
@@ -43,7 +43,12 @@ class EditorController:
         if name in self.editor.classes:
             del self.editor.classes[name]
             # Deleting relationships that are no longer valid after class deletion
-            self.editor.relationships = filter(lambda x: x[0] != name and x[1] != name, self.editor.relationships)
+            toRemove = []
+            for (src, dst) in self.editor.relationships:
+                if name == src or name == dst:
+                    toRemove.append((src, dst))
+            for (src, dst) in toRemove:
+                self.editor.relationships.discard((src, dst))
             self.ui.uiFeedback(f'Deleted class {name}!')
         else:
             self.ui.uiError(f'No class exists with the name `{name}`')

--- a/src/tests/test_editor.py
+++ b/src/tests/test_editor.py
@@ -23,6 +23,24 @@ class testEditor(unittest.TestCase):
         ctrl.editor.classes['Foo'] = Class('Foo')
         ctrl.classDelete('Bar')
         assert 'Foo' in ctrl.editor.classes, 'Foo did not remain after failed deletion'
+
+    # This is to monitor a bug where a lambda expression cleared the relationships list
+    def testClassDeleteBugfix(self):
+        editor = Editor()
+        ui = CLI()
+        ctrl = EditorController(ui, editor)
+
+        ctrl.classAdd('Foo')
+        ctrl.classAdd('Bar')
+        ctrl.relationshipAdd('Foo', 'Bar')
+        ctrl.classAdd('Quo')
+
+        before = ctrl.editor.relationships
+        ctrl.classDelete('Quo')
+        after = ctrl.editor.relationships
+        print('Bugfix: ', before, after)
+
+        assert before == after, 'Relationships were modified when an unrelated class was deleted'
         
     def testClassRenameSuccess(self):
         editor = Editor()


### PR DESCRIPTION
When testing MVC I noticed that deleting classes was messing up the relationship output. Turns out I misused the lambda and I feel its easiest to use direct code until it poses an issue, which it shouldn't. I added a test case to make sure this stays patched.