### PR TITLE
Change JSON format to the new specification

### DIFF
--- a/src/controller/editor_controller.py
+++ b/src/controller/editor_controller.py
@@ -22,12 +22,12 @@ class EditorController:
         with open(filename, 'r') as f:
             data = f.read()
             obj = json.loads(data)
-            for name in obj['classes']:
-                self.classAdd(name)
-                for attr in obj['classes'][name]['attributes']:
-                    self.addAttribute(name, attr)
+            for clazz in obj['classes']:
+                self.classAdd(clazz['name'])
+                for attr in clazz['fields']:
+                    self.addAttribute(clazz['name'], attr)
             for rel in obj['relationships']:
-                self.relationshipAdd(rel['src'], rel['dst'], Type.make(rel['type'].lower()))
+                self.relationshipAdd(rel['source'], rel['destination'], Type.make(rel['type'].lower()))
                         
         self.ui.uiFeedback(f'=--> Loaded from {filename}!')
 

--- a/src/model/editor_model.py
+++ b/src/model/editor_model.py
@@ -16,10 +16,12 @@ class Editor:
 class EditorEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Editor):
-            return {'classes': obj.classes, 'relationships': list(obj.relationships)}
+            return {'classes': list(obj.classes.values()), 'relationships': list(obj.relationships)}
         if isinstance(obj, Class):
-            return {'name': obj.name, 'attributes': list(obj.attributtesSets)}
+            # return {'name': obj.name, 'attributes': list(obj.attributtesSets)}
+            # TODO: make classes for fields and methods so that we can check for them here
+            return {'name': obj.name, 'fields': list(obj.attributtesSets), 'methods': ['nil']}
         if isinstance(obj, Relationship):
             # TODO: I have yet to check the formatting here
-            return {'src': obj.src, 'dst': obj.dst, 'type': obj.typ.display()}
+            return {'source': obj.src, 'destination': obj.dst, 'type': obj.typ.display()}
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
Change JSON format to the new specification. Once methods and fields are implemented, the fields and methods part in the JSON encoder will need to be modified.