### PR TITLE
Fix Redo bug and undo/redo api (+ comments)

### DIFF
--- a/src/controller/editor_controller.py
+++ b/src/controller/editor_controller.py
@@ -164,27 +164,58 @@ class EditorController:
                 self.ui.uiFeedback(f'Loaded from {filename}!')
         finally:
             self.ui.silent_mode = False
+    
+    def undo(self):
+        self.stepCmd(True)
 
-    # Function for Undo/Redo
+    def redo(self):
+        self.stepCmd(False)
+
+    # Implementation function for Undo/Redo
     # Steps through the command stack in different directions depending on the command
     def stepCmd(self, undo: bool):
         if len(self.editor.action_stack) == 0:
             self.ui.uiError('No actions have been performed yet')
             return
         if undo:
-            self.editor.action_stack[self.editor.action_idx].undo(self)
-            if self.editor.action_idx > 0:
+            # We allow the action idx to go to -1 so that the very first command
+            # is not skipped when doing redo
+            if self.editor.action_idx > -1:
+                self.editor.action_stack[self.editor.action_idx].undo(self)
                 self.editor.action_idx -= 1
+                if self.editor.action_idx >= 0:
+                    # If we did not undo the first command, we have commands we can still undo
+                    self.editor.can_undo = True
+                else:
+                    # If we did undo the first command, we can no longer undo
+                    self.editor.can_undo = False
+                # By undoing any command, we can redo
+                self.editor.can_redo = True
+            else:
+                # If we did undo the first command, we can no longer undo
+                self.editor.can_undo = False
         else:
             self.editor.action_idx += 1
             if self.editor.action_idx >= len(self.editor.action_stack):
+                # If we are past the latest command, there is nothing left to redo
                 self.editor.action_idx = len(self.editor.action_stack) - 1
-            self.editor.action_stack[self.editor.action_idx].execute(self)
+                self.editor.can_redo = False
+            else:
+                self.editor.action_stack[self.editor.action_idx].execute(self)
+                if self.editor.action_idx == len(self.editor.action_stack) - 1:
+                    # If we just now called redo on the latest command, there is nothing left to redo
+                    self.editor.can_redo = False
+                else:
+                    # Otherwise, there is more we can redo
+                    self.editor.can_redo = True
+                # By redoing any command, we can undo
+                self.editor.can_undo = True
         # Recalculate grayed out buttons
         self.ui.updateAccess()
     
     def pushCmd(self, cmd):
         self.editor.pushCmd(cmd)
+        self.editor.can_undo = True
         # Recalculate grayed out buttons
         self.ui.updateAccess()
 

--- a/src/model/editor_model.py
+++ b/src/model/editor_model.py
@@ -8,6 +8,8 @@ class Editor:
         self.relationships = {}
         self.action_stack = []
         self.action_idx = 0
+        self.can_undo = False
+        self.can_redo = False
     
     def getClasses(self):
         ls = [c for c in self.classes]
@@ -38,6 +40,12 @@ class Editor:
 
     def canAddRelationship(self):
         return len(self.classes) > 1
+
+    def canUndo(self):
+        return self.can_undo
+
+    def canRedo(self):
+        return self.can_redo
 
     #===== Command Stack =====#
     

--- a/src/tests/test_editor.py
+++ b/src/tests/test_editor.py
@@ -448,7 +448,7 @@ class testEditor(unittest.TestCase):
         cmd2.execute(ctrl)
         editor.pushCmd(cmd2)
 
-        ctrl.stepCmd(True) # Undo
+        ctrl.undo()
         b1 = Method('run') not in ctrl.editor.classes['Foo'].methods
         assert b1, 'Undo did not revert the latest change'
 
@@ -465,7 +465,31 @@ class testEditor(unittest.TestCase):
         cmd2.execute(ctrl)
         editor.pushCmd(cmd2)
 
-        ctrl.stepCmd(True) # Undo
-        ctrl.stepCmd(False) # Redo
+        ctrl.undo()
+        ctrl.redo()
         b1 = Method('run') in ctrl.editor.classes['Foo'].methods
         assert b1, 'Redo did not reapply the latest undo'
+
+    def testRedo2(self):
+        editor = Editor()
+        ui = CLI()
+        ctrl = EditorController(ui, editor)
+
+        cmd1 = CommandClassAdd('Foo')
+        cmd1.execute(ctrl)
+        editor.pushCmd(cmd1)
+
+        cmd2 = CommandMethodAdd('Foo', 'run', ['a', 'b', 'c'])
+        cmd2.execute(ctrl)
+        editor.pushCmd(cmd2)
+
+        cmd3 = CommandClassAdd('Baz')
+        cmd3.execute(ctrl)
+        editor.pushCmd(cmd3)
+
+        ctrl.undo()
+        ctrl.undo()
+        ctrl.redo()
+        b1 = Method('run') in ctrl.editor.classes['Foo'].methods
+        b2 = 'Baz' not in ctrl.editor.classes
+        assert b1 and b2, 'Redo failed on double undo'

--- a/src/view/ui_cli.py
+++ b/src/view/ui_cli.py
@@ -106,9 +106,9 @@ class CLI(ui_interface.UI):
                 case 'load':
                     controller.load()
                 case 'undo':
-                    controller.stepCmd(True)
+                    controller.undo()
                 case 'redo':
-                    controller.stepCmd(False)
+                    controller.redo()
                 case 'list':
                     self.listCommands(controller)
                 case 'help':

--- a/src/view/ui_gui.py
+++ b/src/view/ui_gui.py
@@ -291,10 +291,10 @@ class GUI(ui_interface.UI):
         button_save = tk.Button(self.toolbar, name="help", text="Help", command=lambda: self.showHelp()) #command=self.relationshipCommands)
         button_save.pack(side=tk.LEFT, padx=2, pady=2)
 
-        button_undo = tk.Button(self.toolbar, name="undo", text="Undo", command=lambda: self.controller.stepCmd(True))
+        button_undo = tk.Button(self.toolbar, name="undo", text="Undo", command=lambda: self.controller.undo())
         button_undo.pack(side=tk.LEFT, padx=2, pady=2)
 
-        button_redo = tk.Button(self.toolbar, name="redo", text="Redo", command=lambda: self.controller.stepCmd(False))
+        button_redo = tk.Button(self.toolbar, name="redo", text="Redo", command=lambda: self.controller.redo())
         button_redo.pack(side=tk.LEFT, padx=2, pady=2)
     
     def updateAccess(self):
@@ -324,6 +324,20 @@ class GUI(ui_interface.UI):
             b.config(state=tk.NORMAL)
         else:
             b = self.toolbar.nametowidget("relationships")
+            b.config(state=tk.DISABLED)
+
+        if self.controller.editor.canUndo():
+            b = self.toolbar.nametowidget("undo")
+            b.config(state=tk.NORMAL)
+        else:
+            b = self.toolbar.nametowidget("undo")
+            b.config(state=tk.DISABLED)
+
+        if self.controller.editor.canRedo():
+            b = self.toolbar.nametowidget("redo")
+            b.config(state=tk.NORMAL)
+        else:
+            b = self.toolbar.nametowidget("redo")
             b.config(state=tk.DISABLED)
 
 


### PR DESCRIPTION
This PR fixes grievances with the Undo/Redo system. Specifically, we
- fixed redo after undoing to the first command (it would skip to redoing the 2nd command)
- added undo() and redo() functions that call stepCmd
- grayed out undo and redo boxes if they are not available to be used (this uses State pattern)
- documented stepCmd with comments detailing the state calculations