### PR TITLE
Add builder pattern for app creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ We have used 6 design patterns in total. Click to see where they are used in the
 - [Singleton (Completions)](src/view/ui_cli.py)
 - [State (can_undo/can_redo)](src/controller/editor_controller.py)
 - [Memento](src/controller/memento.py)
-- ?
+- [Builder](src/model/app_model.py)

--- a/src/main.py
+++ b/src/main.py
@@ -1,25 +1,8 @@
-import model.editor_model
-import view.ui_cli
-import view.ui_gui
-from controller.editor_controller import EditorController  
+from model.app_model import AppDirector  
 import sys
 
-def run_cli(editor):
-    ui = view.ui_cli.CLI()  
-    controller = EditorController(ui, editor)  
-    result = ui.uiRun(controller)  
-    return result  
-
-def run_gui(editor):
-    ui = view.ui_gui.GUI(None) 
-    controller = EditorController(ui, editor)  
-    ui.controller = controller 
-    # We need to gray out options on startup
-    ui.updateAccess()
-    ui.uiRun()  
-
 if __name__ == '__main__':
-    editor = model.editor_model.Editor()  
+    director = AppDirector()
 
     # Default mode is GUI
     ui_mode = 'gui'
@@ -31,12 +14,14 @@ if __name__ == '__main__':
     while True:
         if ui_mode == 'cli':
             # Run CLI and check if we need to switch
-            result = run_cli(editor)
+            app = director.makeAppCLI()
+            result = app.run()
             if result == 'switch_to_gui':
                 ui_mode = 'gui'  # Switch to GUI
             else:
                 break  
         else:
             # Run GUI
-            run_gui(editor)
+            app = director.makeAppGUI()
+            app.run()
             break

--- a/src/model/app_model.py
+++ b/src/model/app_model.py
@@ -1,0 +1,68 @@
+from view.ui_cli import CLI
+from view.ui_gui import GUI
+from model.editor_model import Editor
+from controller.editor_controller import EditorController  
+
+class App:
+    def __init__(self):
+        self.ui = None
+
+    def run(self):
+        if self.ui is None:
+            print('ERROR: App created without UI component')
+            return
+        return self.ui.uiRun()
+
+class AppBuilder:
+    def __init__(self):
+        self.editor = None
+        self.reset()
+    
+    def reset(self):
+        self.app = App()
+    
+    def getResult(self):
+        return self.app
+    
+    def fail(self, msg):
+        print(msg)
+        self.app = None
+    
+    def setUI(self, ui):
+        self.app.ui = ui
+
+    def makeEditor(self):
+        self.editor = Editor()  
+    
+    def makeController(self):
+        if self.editor is None or self.app.ui is None:
+            self.fail('ERROR: Tried to make controller without components')
+            return
+        self.controller = EditorController(self.app.ui, self.editor)
+    
+    def linkControllerToUI(self):
+        if self.app.ui is None or self.controller is None:
+            self.fail('ERROR: Missing UI or Controller element')
+            return
+        self.app.ui.controller = self.controller
+
+class AppDirector:
+    def __init__(self):
+        self.builder = AppBuilder()
+        
+    def makeAppCLI(self):
+        self.builder.setUI(CLI())
+        self.builder.makeEditor()
+        self.builder.makeController()
+        self.builder.linkControllerToUI()
+        return self.builder.getResult()
+
+    def makeAppGUI(self):
+        self.builder.setUI(GUI())
+        self.builder.makeEditor()
+        self.builder.makeController()
+        self.builder.linkControllerToUI()
+        app = self.builder.getResult()
+        # We need to gray out options on startup
+        app.ui.updateAccess()
+        return app

--- a/src/tests/test_editor_controller.py
+++ b/src/tests/test_editor_controller.py
@@ -39,7 +39,7 @@ class testEditorController(unittest.TestCase):
 
     def testSaveGui(self):
         editor = Editor()
-        ui = GUI(None)
+        ui = GUI()
         ctrl = EditorController(ui, editor)
         ui.controller = ctrl
         ctrl.ui.uiFeedback = unittest.mock.Mock()
@@ -64,7 +64,7 @@ class testEditorController(unittest.TestCase):
 
     def testSaveGuiRelLineMismatch(self):
         editor = Editor()
-        ui = GUI(None)
+        ui = GUI()
         ctrl = EditorController(ui, editor)
         ui.controller = ctrl
         ctrl.ui.uiFeedback = unittest.mock.Mock()
@@ -98,7 +98,7 @@ class testEditorController(unittest.TestCase):
 
     def testSaveGuiEmpty(self):
         editor = Editor()
-        ui = GUI(None)
+        ui = GUI()
         ctrl = EditorController(ui, editor)
         ui.controller = ctrl
         ctrl.ui.uiFeedback = unittest.mock.Mock()
@@ -136,7 +136,7 @@ class testEditorController(unittest.TestCase):
 
     def testLoadGui(self):
         editor = Editor()
-        ui = GUI(None)
+        ui = GUI()
         ctrl = EditorController(ui, editor)
         ui.controller = ctrl
         ctrl.ui.uiFeedback = unittest.mock.Mock()
@@ -151,7 +151,7 @@ class testEditorController(unittest.TestCase):
 
     def testLoadGuiEmpty(self):
         editor = Editor()
-        ui = GUI(None)
+        ui = GUI()
         ctrl = EditorController(ui, editor)
         ui.controller = ctrl
         ctrl.ui.uiFeedback = unittest.mock.Mock()
@@ -166,7 +166,7 @@ class testEditorController(unittest.TestCase):
 
     def testPushCmd1(self):
         editor = Editor()
-        ui = GUI(None)
+        ui = GUI()
         ctrl = EditorController(ui, editor)
         ui.controller = ctrl
         ctrl.ui.uiFeedback = unittest.mock.Mock()
@@ -195,7 +195,7 @@ class testEditorController(unittest.TestCase):
 
     def testHelpGUI(self):
         editor = Editor()
-        ui = GUI(None)
+        ui = GUI()
         ctrl = EditorController(ui, editor)
         ui.controller = ctrl
         ctrl.ui.uiFeedback = unittest.mock.Mock()

--- a/src/view/ui_cli.py
+++ b/src/view/ui_cli.py
@@ -77,7 +77,7 @@ class CLI(ui_interface.UI):
         filename = self.uiQuery('File Name to Open: ')
         return filename
         
-    def uiRun(self, controller):
+    def uiRun(self):
         print('Welcome to our Unified Modeling Language (UML) program! Please enter a valid command.')
         
         # This is not an amazing solution, have to repeat changes
@@ -91,28 +91,28 @@ class CLI(ui_interface.UI):
             command = command.strip()
             match command:
                 case 'class':
-                    self.classCommands(controller)
+                    self.classCommands(self.controller)
                 case 'relationship':
-                    self.relationshipCommands(controller)
+                    self.relationshipCommands(self.controller)
                 case 'field':
-                    self.fieldCommands(controller)
+                    self.fieldCommands(self.controller)
                 case 'method':
-                    self.methodCommands(controller)
+                    self.methodCommands(self.controller)
                 case 'parameter':
-                    self.parameterCommands(controller)
+                    self.parameterCommands(self.controller)
                 case 'save':
-                    controller.save()
+                    self.controller.save()
                 case 'load':
-                    controller.load()
+                    self.controller.load()
                 case 'undo':
-                    controller.undo()
+                    self.controller.undo()
                 case 'redo':
-                    controller.redo()
+                    self.controller.redo()
                 case 'list':
-                    self.listCommands(controller)
+                    self.listCommands(self.controller)
                 case 'help':
                     print('These are valid commands: class, relationship, field, method, parameter, save, load, undo, redo, list, switch, exit.')
-                    controller.editorHelp()
+                    self.controller.editorHelp()
                 case 'exit':
                     quit = True
                     break

--- a/src/view/ui_gui.py
+++ b/src/view/ui_gui.py
@@ -8,8 +8,7 @@ import json
 import math
 
 class GUI(ui_interface.UI):
-    def __init__(self, controller):
-        self.controller = controller
+    def __init__(self):
         self.silent_mode = False
         self.root = tk.Tk()
         self.root.title("UML Program")


### PR DESCRIPTION
Add builder pattern when creating the editor application. This seems silly at first, but it makes the creation of the interface more clean and would probably be useful if we somehow had to target other interfaces.